### PR TITLE
Adiciona `is_master_healthy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ Nesse caso a variável `dados` seria uma lista com todos os valores das envs:
 Retorna o endereço do mesos que atualmente é o lider do cluster. Essa função depende
 da `get_option`. Faz a chamada `get_option("MESOS", "ADDRESS")`
 
+## mesos.sdk.is_master_healthy()
+
+Dada uma URL de um master, acessa `<URL>/health` e retorna True em caso de HTTP 200 OK, False caso contrário.
+Essa função usa timeout de 2s
+

--- a/asgard/sdk/mesos/__init__.py
+++ b/asgard/sdk/mesos/__init__.py
@@ -1,6 +1,8 @@
 
 import requests
 
+from http import HTTPStatus
+
 from asgard.sdk.options import get_option
 
 def get_mesos_leader_address():
@@ -14,3 +16,12 @@ def get_mesos_leader_address():
         except requests.exceptions.ConnectionError as ConErr:
             pass
             #config.logger.debug({"action": "find-mesos-leader", "try-address": mesos_address, "exception": True})
+
+def is_master_healthy(master_url):
+    try:
+        response = requests.get(f"{master_url}/health", timeout=2, allow_redirects=False)
+        return response.status_code == HTTPStatus.OK
+    except Exception:
+        pass
+
+    return False


### PR DESCRIPTION
IN-2560

Agora, dada um URL para um master, podemos saber se o endpoint `/health`
dele está respondendo.